### PR TITLE
Remove Disable Notifications

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,7 +42,6 @@ const getCurrentBrowser = async () => {
         defaultViewport: null, // no viewport emulation
         userDataDir: path.join(dataDir, 'chromedata'),
         args: [
-          '--disable-notifications',
           '--no-first-run',
           '--disable-infobars',
           '--hide-crash-restore-bubble',


### PR DESCRIPTION
This allows login pages such as Google Login to not block the application. This shows if you have it in place: 
![Screenshot 2024-01-01 125952](https://github.com/fancybits/chrome-capture-for-channels/assets/43685307/df451f8a-7a70-4a67-b962-a698b5a8d62c)
