### PR TITLE
Catch first-run Puppeteer error when Chrome profile is empty

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,6 +10,24 @@ require('console-stamp')(console, {
   format: ':date(yyyy/mm/dd HH:MM:ss.l)',
 })
 
+// --- suppress harmless first-run extension error, but still restart ---
+const EXT_ID = 'jjndjgheafjngoipoacpjgeicjeomjli';
+
+process.on('unhandledRejection', (reason) => {
+  const msg = String(reason?.message || reason || '');
+  if (
+    msg.includes('net::ERR_BLOCKED_BY_CLIENT') &&
+    msg.includes(`chrome-extension://${EXT_ID}/options.html`)
+  ) {
+    console.log('[Info] Restarting due to Chrome extension first-run bootstrap');
+    process.exit(1);  // still exit so supervisor restarts
+    return;
+  }
+  console.error('Unhandled rejection:', reason);
+  process.exit(1);
+});
+// ---------------------------------------------------------------------
+
 // Parse command line arguments
 const argv = require('yargs')
   .option('videoBitrate', {


### PR DESCRIPTION
In Docker, when the container was being run for the first time and the Puppeteer Stream extension was being installed in an empty Chrome profile, this error was generated causing an internal restart:
```node
  enableExtensions: [ '/home/chrome/node_modules/puppeteer-stream/extension' ]
}
179 |                     ensureNewDocumentNavigation = !!response.loaderId;
180 |                     if (response.errorText === 'net::ERR_HTTP_RESPONSE_CODE_FAILURE') {
181 |                         return null;
182 |                     }
183 |                     return response.errorText
184 |                         ? new Error(`${response.errorText} at ${url}`)
                                ^
error: net::ERR_BLOCKED_BY_CLIENT at chrome-extension://jjndjgheafjngoipoacpjgeicjeomjli/options.html#55200
      at navigate (/home/chrome/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/Frame.js:184:27)
[2025/09/11 06:54:14.681] New target page created: about:blank
[2025/09/11 06:54:14.691] Target page changed: chrome-extension://jjndjgheafjngoipoacpjgeicjeomjli/options.html#55200
Bun v1.2.21 (Linux x64)
Cleaning up...
```
Now with a Chrome profile created, and the Chrome extension installed, the process would start error-free. This error is actually harmless, and the restart process is working as it should. Capturing this error, and replacing it with log entry, followed by a restart seems like a good solution. With the error trapped, it now looks like this:
```node
  enableExtensions: [ '/home/chrome/node_modules/puppeteer-stream/extension' ]
}
[2025/09/11 07:22:54.767] [Info] Restarting due to Chrome extension first-run bootstrap
Cleaning up...
```